### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/326/81/85632681.geojson
+++ b/data/856/326/81/85632681.geojson
@@ -859,6 +859,11 @@
     },
     "wof:country":"WS",
     "wof:country_alpha3":"WSM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"62fe23a206b395eadc509f0868447ec5",
     "wof:hierarchy":[
         {
@@ -875,7 +880,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1566652706,
+    "wof:lastmodified":1582379109,
     "wof:name":"Samoa",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/890/416/609/890416609.geojson
+++ b/data/890/416/609/890416609.geojson
@@ -396,6 +396,10 @@
     },
     "wof:country":"WS",
     "wof:created":1469051144,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "unknown"
+    ],
     "wof:geomhash":"07f54a2231bfdf023d563fbf118bc9c5",
     "wof:hierarchy":[
         {
@@ -406,7 +410,7 @@
         }
     ],
     "wof:id":890416609,
-    "wof:lastmodified":1566652734,
+    "wof:lastmodified":1582379110,
     "wof:name":"Apia",
     "wof:parent_id":85680915,
     "wof:placetype":"locality",

--- a/data/890/435/137/890435137.geojson
+++ b/data/890/435/137/890435137.geojson
@@ -66,6 +66,9 @@
     },
     "wof:country":"WS",
     "wof:created":1469052056,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"213ebdfe474b2fa41479f82e7b40af70",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890435137,
-    "wof:lastmodified":1566652741,
+    "wof:lastmodified":1582379110,
     "wof:name":"Vailoa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.