### PR TITLE
Name updates

### DIFF
--- a/data/856/326/81/85632681.geojson
+++ b/data/856/326/81/85632681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.240415,
-    "geom:area_square_m":2887663216.732316,
+    "geom:area_square_m":2887663463.456932,
     "geom:bbox":"-172.815219,-14.074901,-171.390994,-13.437429",
     "geom:latitude":-13.742918,
     "geom:longitude":-172.171589,
@@ -52,6 +52,9 @@
     "name:arg_x_preferred":[
         "Samoa"
     ],
+    "name:ary_x_preferred":[
+        "\u0635\u0627\u0645\u0648\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0633\u0627\u0645\u0648\u0627"
     ],
@@ -72,6 +75,9 @@
     ],
     "name:bam_x_variant":[
         "Samowa"
+    ],
+    "name:ban_x_preferred":[
+        "Samoa"
     ],
     "name:bcl_x_preferred":[
         "Samoa"
@@ -142,6 +148,12 @@
     "name:dan_x_preferred":[
         "Samoa"
     ],
+    "name:deu_at_x_preferred":[
+        "Samoa"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Samoa"
+    ],
     "name:deu_x_preferred":[
         "Samoa"
     ],
@@ -159,6 +171,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03b1\u03bc\u03cc\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Samoa"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Samoa"
     ],
     "name:eng_x_preferred":[
         "Samoa"
@@ -209,6 +227,9 @@
     "name:frp_x_preferred":[
         "Samoa"
     ],
+    "name:frr_x_preferred":[
+        "Samoa"
+    ],
     "name:fry_x_preferred":[
         "Samo\u00e4"
     ],
@@ -219,6 +240,9 @@
         "Samowaa"
     ],
     "name:gag_x_preferred":[
+        "Samoa"
+    ],
+    "name:gcr_x_preferred":[
         "Samoa"
     ],
     "name:ger_x_variant":[
@@ -517,6 +541,9 @@
     "name:pol_x_preferred":[
         "Samoa"
     ],
+    "name:por_br_x_preferred":[
+        "Samoa"
+    ],
     "name:por_x_preferred":[
         "Samoa"
     ],
@@ -594,6 +621,9 @@
     "name:sqi_x_preferred":[
         "Samoa"
     ],
+    "name:srd_x_preferred":[
+        "Samoa"
+    ],
     "name:srp_x_preferred":[
         "\u0421\u0430\u043c\u043e\u0430"
     ],
@@ -607,6 +637,9 @@
         "Samoa"
     ],
     "name:szl_x_preferred":[
+        "Samoa"
+    ],
+    "name:szy_x_preferred":[
         "Samoa"
     ],
     "name:tah_x_preferred":[
@@ -712,11 +745,29 @@
     "name:yue_x_preferred":[
         "\u85a9\u6469\u4e9e"
     ],
+    "name:zea_x_preferred":[
+        "Samoa"
+    ],
     "name:zha_x_preferred":[
         "Samoa"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u8428\u6469\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u85a9\u6469\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Samoa"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u85a9\u6469\u4e9e"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u8428\u6469\u4e9a"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u85a9\u6469\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u8428\u6469\u4e9a"
@@ -881,7 +932,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1583797458,
+    "wof:lastmodified":1587428765,
     "wof:name":"Samoa",
     "wof:parent_id":102191583,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.