### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/587/526/9/1125875269.geojson
+++ b/data/112/587/526/9/1125875269.geojson
@@ -28,7 +28,13 @@
     "name:ceb_x_preferred":[
         "Matatufu"
     ],
+    "name:deu_x_preferred":[
+        "Matatufu"
+    ],
     "name:eng_x_preferred":[
+        "Matatufu"
+    ],
+    "name:fra_x_preferred":[
         "Matatufu"
     ],
     "name:nld_x_preferred":[
@@ -71,7 +77,7 @@
         }
     ],
     "wof:id":1125875269,
-    "wof:lastmodified":1566652745,
+    "wof:lastmodified":1690921754,
     "wof:name":"Matatufu",
     "wof:parent_id":85680925,
     "wof:placetype":"locality",

--- a/data/112/588/788/1/1125887881.geojson
+++ b/data/112/588/788/1/1125887881.geojson
@@ -28,10 +28,19 @@
     "name:ceb_x_preferred":[
         "Satapuala"
     ],
+    "name:deu_x_preferred":[
+        "Satapuala"
+    ],
     "name:eng_x_preferred":[
         "Satapuala"
     ],
+    "name:fra_x_preferred":[
+        "Satapuala"
+    ],
     "name:nld_x_preferred":[
+        "Satapuala"
+    ],
+    "name:pol_x_preferred":[
         "Satapuala"
     ],
     "qs_pg:aaroncc":"WS",
@@ -71,7 +80,7 @@
         }
     ],
     "wof:id":1125887881,
-    "wof:lastmodified":1566652745,
+    "wof:lastmodified":1690921753,
     "wof:name":"Satapuala",
     "wof:parent_id":85680917,
     "wof:placetype":"locality",

--- a/data/112/594/315/9/1125943159.geojson
+++ b/data/112/594/315/9/1125943159.geojson
@@ -34,7 +34,13 @@
     "name:eng_x_preferred":[
         "Afega"
     ],
+    "name:fra_x_preferred":[
+        "Afega"
+    ],
     "name:haw_x_preferred":[
+        "Afega"
+    ],
+    "name:ita_x_preferred":[
         "Afega"
     ],
     "name:jpn_x_preferred":[
@@ -97,7 +103,7 @@
         }
     ],
     "wof:id":1125943159,
-    "wof:lastmodified":1566652744,
+    "wof:lastmodified":1690921752,
     "wof:name":"Afenga",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/602/808/7/1126028087.geojson
+++ b/data/112/602/808/7/1126028087.geojson
@@ -28,7 +28,13 @@
     "name:ceb_x_preferred":[
         "Tuasivi"
     ],
+    "name:deu_x_preferred":[
+        "Tuasivi"
+    ],
     "name:eng_x_preferred":[
+        "Tuasivi"
+    ],
+    "name:fra_x_preferred":[
         "Tuasivi"
     ],
     "name:nld_x_preferred":[
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":1126028087,
-    "wof:lastmodified":1566652744,
+    "wof:lastmodified":1690921753,
     "wof:name":"Tuasivi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/196/919/421196919.geojson
+++ b/data/421/196/919/421196919.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:cat_x_preferred":[
+        "S\u0101lelologa"
+    ],
     "name:deu_x_preferred":[
         "Salelologa"
     ],
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421196919,
-    "wof:lastmodified":1566652723,
+    "wof:lastmodified":1690921722,
     "wof:name":"Salelologa",
     "wof:parent_id":85680933,
     "wof:placetype":"locality",

--- a/data/421/199/465/421199465.geojson
+++ b/data/421/199/465/421199465.geojson
@@ -35,6 +35,9 @@
     "name:jpn_x_preferred":[
         "\u30e0\u30ea\u30d5\u30a1\u30cc\u30a2\u6751"
     ],
+    "name:kat_x_preferred":[
+        "\u10db\u10e3\u10da\u10d8\u10e4\u10d0\u10dc\u10e3\u10d0"
+    ],
     "name:lat_x_preferred":[
         "Mulifanua"
     ],
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":421199465,
-    "wof:lastmodified":1566652724,
+    "wof:lastmodified":1690921723,
     "wof:name":"Mulifanua",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/326/81/85632681.geojson
+++ b/data/856/326/81/85632681.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":8.0,
     "mz:min_zoom":3.0,
+    "name:abk_x_preferred":[
+        "\u0421\u0430\u043c\u043e\u0430"
+    ],
     "name:ace_x_preferred":[
         "Samoa"
     ],
@@ -46,6 +49,15 @@
     "name:amh_x_variant":[
         "\u1233\u121e\u12a0"
     ],
+    "name:ami_x_preferred":[
+        "Samoa"
+    ],
+    "name:ang_x_preferred":[
+        "Samoa"
+    ],
+    "name:anp_x_preferred":[
+        "\u0938\u093e\u092e\u094b\u0906"
+    ],
     "name:ara_x_preferred":[
         "\u0633\u0627\u0645\u0648\u0627"
     ],
@@ -59,6 +71,9 @@
         "\u0633\u0627\u0645\u0648\u0627"
     ],
     "name:ast_x_preferred":[
+        "Samoa"
+    ],
+    "name:avk_x_preferred":[
         "Samoa"
     ],
     "name:azb_x_preferred":[
@@ -94,6 +109,9 @@
     "name:bho_x_preferred":[
         "\u0938\u092e\u094b\u0906"
     ],
+    "name:bis_x_preferred":[
+        "Samoa"
+    ],
     "name:bjn_x_preferred":[
         "Samoa"
     ],
@@ -127,11 +145,20 @@
     "name:ceb_x_preferred":[
         "Samoa"
     ],
+    "name:ceb_x_variant":[
+        "Samowa"
+    ],
     "name:ces_x_preferred":[
         "Samoa"
     ],
     "name:che_x_preferred":[
         "\u0421\u0430\u043c\u043e\u0430"
+    ],
+    "name:chr_x_preferred":[
+        "\u13cc\u13bc\u13a0"
+    ],
+    "name:chy_x_preferred":[
+        "Samoa"
     ],
     "name:ckb_x_preferred":[
         "\u0633\u0627\u0645\u0648\u0627"
@@ -144,6 +171,9 @@
     ],
     "name:cym_x_preferred":[
         "Samoa"
+    ],
+    "name:dag_x_preferred":[
+        "Western Samoa"
     ],
     "name:dan_x_preferred":[
         "Samoa"
@@ -239,6 +269,9 @@
     "name:ful_x_preferred":[
         "Samowaa"
     ],
+    "name:fur_x_preferred":[
+        "Samoe"
+    ],
     "name:gag_x_preferred":[
         "Samoa"
     ],
@@ -285,6 +318,12 @@
     "name:hau_x_preferred":[
         "Samowa"
     ],
+    "name:hau_x_variant":[
+        "Samoa"
+    ],
+    "name:haw_x_preferred":[
+        "S\u0101moa Komohana"
+    ],
     "name:hbs_x_preferred":[
         "Samoa"
     ],
@@ -317,6 +356,9 @@
     ],
     "name:ido_x_preferred":[
         "Samoa"
+    ],
+    "name:iku_x_preferred":[
+        "\u1595\u14a5\u14f5\u14a8"
     ],
     "name:ile_x_preferred":[
         "Samoa"
@@ -351,6 +393,9 @@
     "name:jpn_x_variant":[
         "\u30b5\u30e2\u30a2\u72ec\u7acb\u56fd",
         "\u897f\u30b5\u30e2\u30a2"
+    ],
+    "name:kaa_x_preferred":[
+        "Samoa"
     ],
     "name:kal_x_preferred":[
         "Samoa"
@@ -412,6 +457,9 @@
     "name:lit_x_preferred":[
         "Samoa"
     ],
+    "name:lld_x_preferred":[
+        "Samoa"
+    ],
     "name:lmo_x_preferred":[
         "Samoa"
     ],
@@ -439,6 +487,12 @@
     "name:mar_x_variant":[
         "\u0938\u093e\u092e\u094b\u0906"
     ],
+    "name:mhr_x_preferred":[
+        "\u0421\u0430\u043c\u043e\u0430"
+    ],
+    "name:min_x_preferred":[
+        "Samoa"
+    ],
     "name:mkd_x_preferred":[
         "\u0421\u0430\u043c\u043e\u0430"
     ],
@@ -447,6 +501,12 @@
     ],
     "name:mlt_x_preferred":[
         "Samoa"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc1\uabe5\uabc3\uabe3\uabd1\uabe5"
+    ],
+    "name:mon_x_preferred":[
+        "\u0421\u0430\u043c\u043e\u0430"
     ],
     "name:mri_x_preferred":[
         "H\u0101moa ki te Uru"
@@ -583,6 +643,9 @@
     "name:sgs_x_preferred":[
         "Samuoa"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101e\u1083\u1087\u1019\u1030\u101d\u103a\u1038\u101d\u1083\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc3\u0dd0\u0db8\u0ddd\u0dc0\u0dcf"
     ],
@@ -596,11 +659,17 @@
     "name:sme_x_preferred":[
         "Samoa"
     ],
+    "name:smn_x_preferred":[
+        "Samoa"
+    ],
     "name:smo_x_preferred":[
         "S\u0101moa"
     ],
     "name:smo_x_variant":[
         "Malo Sa\u2019oloto Tuto\u2019atasi o Samoa",
+        "Samoa"
+    ],
+    "name:sms_x_preferred":[
         "Samoa"
     ],
     "name:sna_x_preferred":[
@@ -651,6 +720,9 @@
     "name:tat_x_preferred":[
         "\u0421\u0430\u043c\u043e\u0430"
     ],
+    "name:tay_x_preferred":[
+        "Samoa"
+    ],
     "name:tel_x_preferred":[
         "\u0c38\u0c2e\u0c4b\u0c35\u0c3e"
     ],
@@ -669,10 +741,16 @@
     "name:tir_x_preferred":[
         "\u1233\u121e\u12a0"
     ],
+    "name:tok_x_preferred":[
+        "ma Samowa"
+    ],
     "name:ton_x_preferred":[
         "Ha\u02bbamoa"
     ],
     "name:tpi_x_preferred":[
+        "Samoa"
+    ],
+    "name:trv_x_preferred":[
         "Samoa"
     ],
     "name:tuk_x_preferred":[
@@ -683,6 +761,9 @@
     ],
     "name:tur_x_variant":[
         "Ba\u011f\u0131ms\u0131z Samoa Devleti"
+    ],
+    "name:udm_x_preferred":[
+        "\u0421\u0430\u043c\u043e\u0430"
     ],
     "name:uig_x_preferred":[
         "\u0633\u0627\u0645\u0648\u0626\u0627"
@@ -700,6 +781,9 @@
         "\u0633\u0627\u0645\u0648\u0622"
     ],
     "name:uzb_x_preferred":[
+        "Samoa"
+    ],
+    "name:vec_x_preferred":[
         "Samoa"
     ],
     "name:vep_x_preferred":[
@@ -720,6 +804,9 @@
     ],
     "name:war_x_preferred":[
         "Samoa"
+    ],
+    "name:wls_x_preferred":[
+        "Ha'amoa"
     ],
     "name:wol_x_preferred":[
         "Samowaa"
@@ -997,7 +1084,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1617827636,
+    "wof:lastmodified":1690921721,
     "wof:name":"Samoa",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/809/15/85680915.geojson
+++ b/data/856/809/15/85680915.geojson
@@ -56,6 +56,9 @@
     "name:eus_x_preferred":[
         "Tuamasaga"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0648\u0627\u0645\u0627\u0633\u0627\u06af\u0627"
+    ],
     "name:fin_x_preferred":[
         "Tuamasaga"
     ],
@@ -74,6 +77,12 @@
     "name:hrv_x_preferred":[
         "Tuamasaga"
     ],
+    "name:hun_x_preferred":[
+        "Tuamasaga"
+    ],
+    "name:hye_x_preferred":[
+        "\u054f\u0578\u0582\u0561\u0574\u0561\u057d\u0561\u0563\u0561"
+    ],
     "name:ind_x_preferred":[
         "Tuamasaga"
     ],
@@ -91,6 +100,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud22c\uc544\ub9c8\uc0ac\uac00 \uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\ud22c\uc544\ub9c8\uc0ac\uac00\uad6c"
     ],
     "name:lat_x_preferred":[
         "Tuamasaga"
@@ -287,7 +299,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504672,
+    "wof:lastmodified":1690921720,
     "wof:name":"Tuamasaga",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/17/85680917.geojson
+++ b/data/856/809/17/85680917.geojson
@@ -146,6 +146,9 @@
     "name:slk_x_preferred":[
         "A\u2019ana"
     ],
+    "name:smo_x_preferred":[
+        "A'ana"
+    ],
     "name:spa_x_preferred":[
         "A'ana"
     ],
@@ -298,7 +301,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504671,
+    "wof:lastmodified":1690921717,
     "wof:name":"A'ana",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/21/85680921.geojson
+++ b/data/856/809/21/85680921.geojson
@@ -98,6 +98,9 @@
     "name:kor_x_preferred":[
         "\uc544\uc774\uac00\uc774\ub808\ud0c0\uc774 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc544\uc774\uac00\uc774\ub808\ud0c0\uc774\uad6c"
+    ],
     "name:lat_x_preferred":[
         "Aiga-i-le-Tai"
     ],
@@ -109,6 +112,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0906\u092f\u0917-\u0906\u092f-\u0932\u0947-\u0924\u093e\u0908"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0410\u0438\u0433\u0430-\u0438-\u043b\u0435-\u0422\u0430\u0438"
     ],
     "name:mrj_x_preferred":[
         "\u0410\u0438\u0433\u0430-\u0438-\u043b\u0435-\u0422\u0430\u0438"
@@ -138,6 +144,9 @@
         "\u0d85\u0dba\u0dd2\u0d9c\u0dcf-\u0d89-\u0dbd\u0dd9-\u0da7\u0dba\u0dd2"
     ],
     "name:slk_x_preferred":[
+        "Aiga-i-le-Tai"
+    ],
+    "name:smo_x_preferred":[
         "Aiga-i-le-Tai"
     ],
     "name:spa_x_preferred":[
@@ -296,7 +305,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504671,
+    "wof:lastmodified":1690921717,
     "wof:name":"Aiga-i-le-Tai",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/25/85680925.geojson
+++ b/data/856/809/25/85680925.geojson
@@ -53,6 +53,9 @@
     "name:eus_x_preferred":[
         "Atua"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u062e\u0634 \u0622\u062a\u0648\u0622"
+    ],
     "name:fin_x_preferred":[
         "Atua"
     ],
@@ -92,6 +95,9 @@
     "name:kor_x_preferred":[
         "\uc544\ud22c\uc544 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc544\ud22c\uc544\uad6c"
+    ],
     "name:lat_x_preferred":[
         "Atua"
     ],
@@ -129,6 +135,9 @@
         "\u0d85\u0da7\u0dd4\u0dc0\u0dcf"
     ],
     "name:slk_x_preferred":[
+        "Atua"
+    ],
+    "name:smo_x_preferred":[
         "Atua"
     ],
     "name:spa_x_preferred":[
@@ -280,7 +289,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504673,
+    "wof:lastmodified":1690921720,
     "wof:name":"Atua",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/31/85680931.geojson
+++ b/data/856/809/31/85680931.geojson
@@ -110,6 +110,9 @@
     "name:mar_x_preferred":[
         "\u0935-\u0913-\u092b\u094b\u0928\u0949\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0412\u0430-\u043e-\u0424\u043e\u043d\u043e\u0442\u0438"
+    ],
     "name:mrj_x_preferred":[
         "\u0412\u0430\u0430-\u043e-\u0424\u043e\u043d\u043e\u0442\u0438"
     ],
@@ -139,6 +142,9 @@
     ],
     "name:slk_x_preferred":[
         "Va\u2019a-o-Fonoti"
+    ],
+    "name:smo_x_preferred":[
+        "Va'a-o-Fonoti"
     ],
     "name:spa_x_preferred":[
         "Va'a-o-Fonoti"
@@ -290,7 +296,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504672,
+    "wof:lastmodified":1690921718,
     "wof:name":"Va'a-o-Fonoti",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/33/85680933.geojson
+++ b/data/856/809/33/85680933.geojson
@@ -113,6 +113,9 @@
     "name:mar_x_preferred":[
         "\u092b\u093e\u0938\u093e\u0932\u0947\u0932\u0947\u0917\u093e"
     ],
+    "name:mkd_x_preferred":[
+        "\u0424\u0430\u0441\u0430\u043b\u0435\u043b\u0435\u0430\u0433\u0430"
+    ],
     "name:mrj_x_preferred":[
         "\u0424\u0430\u0430\u0441\u0430\u043b\u0435\u043b\u0435\u0430\u0433\u0430"
     ],
@@ -142,6 +145,9 @@
     ],
     "name:slk_x_preferred":[
         "Fa\u2019asaleleaga"
+    ],
+    "name:smo_x_preferred":[
+        "Fa'asaleleaga"
     ],
     "name:spa_x_preferred":[
         "Fa'asaleleaga"
@@ -293,7 +299,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504671,
+    "wof:lastmodified":1690921716,
     "wof:name":"Fa'asaleleaga",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/37/85680937.geojson
+++ b/data/856/809/37/85680937.geojson
@@ -56,6 +56,9 @@
     "name:eus_x_preferred":[
         "Gaga'emauga"
     ],
+    "name:fas_x_preferred":[
+        "\u06af\u0627\u06af\u0627\u0633\u0645\u0648\u06af\u0627"
+    ],
     "name:fin_x_preferred":[
         "Gaga'emauga"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a97\u0abe\u0a97\u0abe'\u0aae\u0abe\u0a89\u0a97\u0abe"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d2\u05d2\u05d0\u05de\u05d0\u05d5\u05d2\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0917\u093e\u0917\u093e'\u090f\u092e\u093e\u0909\u0917\u093e"
@@ -92,6 +98,9 @@
     "name:kor_x_preferred":[
         "\uac00\uac00\uc5d0\ub9c8\uc6b0\uac00 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uac00\uac00\uc5d0\ub9c8\uc6b0\uac00\uad6c"
+    ],
     "name:lat_x_preferred":[
         "Gagaemauga"
     ],
@@ -103,6 +112,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0917\u0917\u093e\u092e\u094b\u0917\u093e"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0413\u0430\u0433\u0430\u0435\u043c\u0430\u0443\u0433\u0430"
     ],
     "name:mrj_x_preferred":[
         "\u0413\u0430\u0433\u0430\u044d\u043c\u0430\u0443\u0433\u0430"
@@ -133,6 +145,9 @@
     ],
     "name:slk_x_preferred":[
         "Gaga\u2019emauga"
+    ],
+    "name:smo_x_preferred":[
+        "Gaga'emauga"
     ],
     "name:spa_x_preferred":[
         "Gaga'emauga"
@@ -286,7 +301,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504672,
+    "wof:lastmodified":1690921719,
     "wof:name":"Gaga'emauga",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/39/85680939.geojson
+++ b/data/856/809/39/85680939.geojson
@@ -71,6 +71,9 @@
     "name:guj_x_preferred":[
         "\u0a97\u0abe\u0a97\u0abe'\u0a88\u0aab\u0acb\u0aae\u0abe\u0a89\u0a97\u0abe"
     ],
+    "name:heb_x_preferred":[
+        "\u05d2\u05d2\u05d0\u05d9\u05e4\u05d5\u05de\u05d0\u05d5\u05d2\u05d4"
+    ],
     "name:hin_x_preferred":[
         "\u0917\u093e\u0917\u093e'\u0907\u092b\u093c\u094b\u092e\u094c\u0917\u093e"
     ],
@@ -98,6 +101,9 @@
     "name:kor_x_preferred":[
         "\uac00\uac00\uc774\ud3ec\ub9c8\uc6b0\uac00 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uac00\uac00\uc774\ud3ec\ub9c8\uc6b0\uac00\uad6c"
+    ],
     "name:lat_x_preferred":[
         "Gagaifomauga"
     ],
@@ -109,6 +115,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0917\u093e\u0917\u093e'\u092b\u094b\u092e\u093e\u0917\u093e"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0413\u0430\u0433\u0430\u0438\u0444\u043e\u043c\u0430\u0443\u0433\u0430"
     ],
     "name:mrj_x_preferred":[
         "\u0413\u0430\u0433\u0430\u0438\u0444\u043e\u043c\u0430\u0443\u0433\u0430"
@@ -139,6 +148,9 @@
     ],
     "name:slk_x_preferred":[
         "Gaga\u2019ifomauga"
+    ],
+    "name:smo_x_preferred":[
+        "Gaga'ifomauga"
     ],
     "name:spa_x_preferred":[
         "Gaga'ifomauga"
@@ -296,7 +308,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504672,
+    "wof:lastmodified":1690921719,
     "wof:name":"Gaga'ifomauga",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/43/85680943.geojson
+++ b/data/856/809/43/85680943.geojson
@@ -56,6 +56,9 @@
     "name:eus_x_preferred":[
         "Vaisigano"
     ],
+    "name:fas_x_preferred":[
+        "\u0648\u0627\u06cc\u0633\u06cc\u06af\u0627\u0646\u0648"
+    ],
     "name:fin_x_preferred":[
         "Vaisigano"
     ],
@@ -95,6 +98,9 @@
     "name:kor_x_preferred":[
         "\ubc14\uc774\uc2dc\uac00\ub178 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ubc14\uc774\uc2dc\uac00\ub178\uad6c"
+    ],
     "name:lat_x_preferred":[
         "Itu Asau"
     ],
@@ -106,6 +112,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0935\u0948\u0936\u093f\u0917\u093e\u0928\u094b"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0412\u0430\u0438\u0441\u0438\u0433\u0430\u043d\u043e"
     ],
     "name:mrj_x_preferred":[
         "\u0412\u0430\u0438\u0441\u0438\u0433\u0430\u043d\u043e"
@@ -135,6 +144,9 @@
         "\u0dc0\u0dba\u0dd2\u0dc3\u0dd2\u0d9c\u0dcf\u0db1\u0ddd"
     ],
     "name:slk_x_preferred":[
+        "Vaisigano"
+    ],
+    "name:smo_x_preferred":[
         "Vaisigano"
     ],
     "name:spa_x_preferred":[
@@ -290,7 +302,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504672,
+    "wof:lastmodified":1690921717,
     "wof:name":"Vaisigano",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/49/85680949.geojson
+++ b/data/856/809/49/85680949.geojson
@@ -98,6 +98,9 @@
     "name:kor_x_preferred":[
         "\uc0ac\ud22c\ud30c\uc774\ud14c\uc544 \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc0ac\ud22c\ud30c\uc774\ud14c\uc544\uad6c"
+    ],
     "name:lat_x_preferred":[
         "Satupaitea"
     ],
@@ -109,6 +112,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0938\u0924\u092a\u0948\u0924\u0940"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0430\u0442\u0443\u043f\u0430\u0438\u0442\u0435\u0458\u0430"
     ],
     "name:mrj_x_preferred":[
         "\u0421\u0430\u0442\u0443\u043f\u0430\u0438\u0442\u0435\u0430"
@@ -139,6 +145,9 @@
     ],
     "name:slk_x_preferred":[
         "Satupa\u2019itea"
+    ],
+    "name:smo_x_preferred":[
+        "Satupa'itea"
     ],
     "name:spa_x_preferred":[
         "Satupa'itea"
@@ -292,7 +301,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504673,
+    "wof:lastmodified":1690921720,
     "wof:name":"Satupa'itea",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/53/85680953.geojson
+++ b/data/856/809/53/85680953.geojson
@@ -59,6 +59,9 @@
     "name:eus_x_preferred":[
         "Palauli"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0627\u0644\u0627\u0626\u0648\u0644\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Palauli"
     ],
@@ -98,6 +101,9 @@
     "name:kor_x_preferred":[
         "\ud314\ub77c\uc6b8\ub9ac \uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud314\ub77c\uc6b8\ub9ac\uad6c"
+    ],
     "name:lat_x_preferred":[
         "Palauli"
     ],
@@ -109,6 +115,9 @@
     ],
     "name:mar_x_preferred":[
         "\u092a\u0932\u093e\u090a\u0932\u0940"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041f\u0430\u043b\u0430\u0443\u043b\u0438"
     ],
     "name:mrj_x_preferred":[
         "\u041f\u0430\u043b\u0430\u0443\u043b\u0438"
@@ -296,7 +305,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1636504672,
+    "wof:lastmodified":1690921718,
     "wof:name":"Palauli",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/890/416/581/890416581.geojson
+++ b/data/890/416/581/890416581.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0641\u0648\u0632\u0649"
+    ],
     "name:deu_x_preferred":[
         "Fusi Ferro"
     ],
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890416581,
-    "wof:lastmodified":1566652733,
+    "wof:lastmodified":1690921737,
     "wof:name":"Fusi",
     "wof:parent_id":85680915,
     "wof:placetype":"locality",

--- a/data/890/416/583/890416583.geojson
+++ b/data/890/416/583/890416583.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0641\u0648\u0632\u0649"
+    ],
     "name:deu_x_preferred":[
         "Fusi Ferro"
     ],
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890416583,
-    "wof:lastmodified":1566652735,
+    "wof:lastmodified":1690921740,
     "wof:name":"Fusi",
     "wof:parent_id":85680925,
     "wof:placetype":"locality",

--- a/data/890/416/607/890416607.geojson
+++ b/data/890/416/607/890416607.geojson
@@ -22,6 +22,9 @@
     "name:ast_x_preferred":[
         "Asaga"
     ],
+    "name:ben_x_preferred":[
+        "\u0985\u09b8\u09be\u0997\u09be"
+    ],
     "name:cat_x_preferred":[
         "Asaga"
     ],
@@ -29,6 +32,9 @@
         "Asaga"
     ],
     "name:fra_x_preferred":[
+        "Asaga"
+    ],
+    "name:gle_x_preferred":[
         "Asaga"
     ],
     "name:hin_x_preferred":[
@@ -50,6 +56,9 @@
         "Asaga"
     ],
     "name:spa_x_preferred":[
+        "Asaga"
+    ],
+    "name:sqi_x_preferred":[
         "Asaga"
     ],
     "qs:name":"Asaga",
@@ -83,7 +92,7 @@
         }
     ],
     "wof:id":890416607,
-    "wof:lastmodified":1566652734,
+    "wof:lastmodified":1690921739,
     "wof:name":"Asaga",
     "wof:parent_id":85680933,
     "wof:placetype":"locality",

--- a/data/890/416/609/890416609.geojson
+++ b/data/890/416/609/890416609.geojson
@@ -30,14 +30,29 @@
     "name:ara_x_preferred":[
         "\u0623\u0628\u064a\u0627"
     ],
+    "name:ary_x_preferred":[
+        "\u0623\u067e\u064a\u0627"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0628\u064a\u0627"
+    ],
     "name:ast_x_preferred":[
+        "Apia"
+    ],
+    "name:avk_x_preferred":[
         "Apia"
     ],
     "name:aze_x_preferred":[
         "Apia"
     ],
+    "name:ban_x_preferred":[
+        "Apia"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u043f\u0456\u044f"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u043f\u0456\u044f"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09aa\u09bf\u09af\u09bc\u09be"
@@ -141,6 +156,9 @@
     "name:hin_x_preferred":[
         "\u090f\u092a\u093f\u092f\u093e"
     ],
+    "name:hin_x_variant":[
+        "\u0906\u092a\u093f\u092f\u093e"
+    ],
     "name:hrv_x_preferred":[
         "Apia"
     ],
@@ -228,6 +246,9 @@
     "name:mya_x_preferred":[
         "\u1021\u1015\u102e\u101a\u102c\u1019\u103c\u102d\u102f\u1037"
     ],
+    "name:nah_x_preferred":[
+        "Apia"
+    ],
     "name:nan_x_preferred":[
         "Apia"
     ],
@@ -263,6 +284,9 @@
     ],
     "name:por_x_preferred":[
         "Apia"
+    ],
+    "name:pus_x_preferred":[
+        "\u0627\u067e\u06cc\u0627"
     ],
     "name:ron_x_preferred":[
         "Apia"
@@ -300,6 +324,9 @@
     "name:sqi_x_preferred":[
         "Apia"
     ],
+    "name:srd_x_preferred":[
+        "\u00c0pia"
+    ],
     "name:srp_x_preferred":[
         "\u0410\u043f\u0438\u0458\u0430"
     ],
@@ -321,11 +348,17 @@
     "name:tel_x_preferred":[
         "\u0c06\u0c2a\u0c3f\u0c2f\u0c3e"
     ],
+    "name:tgk_x_preferred":[
+        "\u0410\u043f\u0438\u0430"
+    ],
     "name:tgl_x_preferred":[
         "Apia"
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e32\u0e1b\u0e35\u0e2d\u0e32"
+    ],
+    "name:tir_x_preferred":[
+        "\u12a3\u1355\u12eb"
     ],
     "name:tpi_x_preferred":[
         "Apia"
@@ -356,6 +389,12 @@
     ],
     "name:war_x_preferred":[
         "Apia"
+    ],
+    "name:wuu_x_preferred":[
+        "\u963f\u76ae\u4e9a"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d0\u10de\u10d8\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u963f\u76ae\u4e9e"
@@ -412,7 +451,7 @@
         }
     ],
     "wof:id":890416609,
-    "wof:lastmodified":1607390883,
+    "wof:lastmodified":1690921740,
     "wof:name":"Apia",
     "wof:parent_id":85680915,
     "wof:placetype":"locality",

--- a/data/890/420/465/890420465.geojson
+++ b/data/890/420/465/890420465.geojson
@@ -37,6 +37,9 @@
     "name:nld_x_preferred":[
         "Sataua"
     ],
+    "name:szl_x_preferred":[
+        "Sataua"
+    ],
     "qs:name":"Sataua",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890420465,
-    "wof:lastmodified":1566652735,
+    "wof:lastmodified":1690921741,
     "wof:name":"Sataua",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/420/469/890420469.geojson
+++ b/data/890/420/469/890420469.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arg_x_preferred":[
+        "Samea"
+    ],
     "name:ast_x_preferred":[
         "\u200eSamea\u200e"
     ],
@@ -37,7 +40,34 @@
     "name:eng_x_preferred":[
         "Samea"
     ],
+    "name:epo_x_preferred":[
+        "Samea"
+    ],
+    "name:eus_x_preferred":[
+        "Samea"
+    ],
+    "name:ext_x_preferred":[
+        "Samea"
+    ],
+    "name:fin_x_preferred":[
+        "Samea"
+    ],
     "name:fra_x_preferred":[
+        "Samea"
+    ],
+    "name:gle_x_preferred":[
+        "Samea"
+    ],
+    "name:glg_x_preferred":[
+        "Samea"
+    ],
+    "name:ido_x_preferred":[
+        "Samea"
+    ],
+    "name:ile_x_preferred":[
+        "Samea"
+    ],
+    "name:ina_x_preferred":[
         "Samea"
     ],
     "name:ita_x_preferred":[
@@ -49,13 +79,25 @@
     "name:nld_x_preferred":[
         "Samea"
     ],
+    "name:oci_x_preferred":[
+        "Samea"
+    ],
+    "name:pol_x_preferred":[
+        "Samea"
+    ],
     "name:por_x_preferred":[
+        "Samea"
+    ],
+    "name:ron_x_preferred":[
         "Samea"
     ],
     "name:rus_x_preferred":[
         "Samea"
     ],
     "name:spa_x_preferred":[
+        "Samea"
+    ],
+    "name:sqi_x_preferred":[
         "Samea"
     ],
     "name:swe_x_preferred":[
@@ -65,6 +107,9 @@
         "Samea"
     ],
     "name:vie_x_preferred":[
+        "Samea"
+    ],
+    "name:vol_x_preferred":[
         "Samea"
     ],
     "name:war_x_preferred":[
@@ -97,7 +142,7 @@
         }
     ],
     "wof:id":890420469,
-    "wof:lastmodified":1566652736,
+    "wof:lastmodified":1690921742,
     "wof:name":"Samea",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/422/957/890422957.geojson
+++ b/data/890/422/957/890422957.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Ulutogia"
     ],
+    "name:deu_x_preferred":[
+        "Ulutogia"
+    ],
     "name:eng_x_preferred":[
         "Ulutogia"
     ],
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890422957,
-    "wof:lastmodified":1566652725,
+    "wof:lastmodified":1690921725,
     "wof:name":"Ulutogia",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/422/959/890422959.geojson
+++ b/data/890/422/959/890422959.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Uafato"
     ],
+    "name:deu_x_preferred":[
+        "Uafato"
+    ],
     "name:ell_x_preferred":[
         "\u039f\u03c5\u03b1\u03c6\u03ac\u03c4\u03bf"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:nld_x_preferred":[
         "Uafato"
+    ],
+    "name:rus_x_preferred":[
+        "\u0423\u0430\u0444\u0430\u0442\u043e"
     ],
     "name:und_x_variant":[
         "Atoe"
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":890422959,
-    "wof:lastmodified":1566652725,
+    "wof:lastmodified":1690921726,
     "wof:name":"Uafato",
     "wof:parent_id":85680931,
     "wof:placetype":"locality",

--- a/data/890/422/967/890422967.geojson
+++ b/data/890/422/967/890422967.geojson
@@ -25,10 +25,16 @@
     "name:ceb_x_preferred":[
         "Saipipi"
     ],
+    "name:deu_x_preferred":[
+        "Saipipi"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03b1\u03ca\u03c0\u03af\u03c0\u03b9"
     ],
     "name:eng_x_preferred":[
+        "Saipipi"
+    ],
+    "name:fra_x_preferred":[
         "Saipipi"
     ],
     "name:nld_x_preferred":[
@@ -65,7 +71,7 @@
         }
     ],
     "wof:id":890422967,
-    "wof:lastmodified":1566652726,
+    "wof:lastmodified":1690921726,
     "wof:name":"Saipipi",
     "wof:parent_id":85680933,
     "wof:placetype":"locality",

--- a/data/890/422/969/890422969.geojson
+++ b/data/890/422/969/890422969.geojson
@@ -124,10 +124,16 @@
     "name:spa_x_preferred":[
         "Saina"
     ],
+    "name:sqi_x_preferred":[
+        "Saina"
+    ],
     "name:swe_x_preferred":[
         "Saina"
     ],
     "name:tur_x_preferred":[
+        "Saina"
+    ],
+    "name:vec_x_preferred":[
         "Saina"
     ],
     "name:zho_x_preferred":[
@@ -164,7 +170,7 @@
         }
     ],
     "wof:id":890422969,
-    "wof:lastmodified":1566652726,
+    "wof:lastmodified":1690921727,
     "wof:name":"Saina",
     "wof:parent_id":85680937,
     "wof:placetype":"locality",

--- a/data/890/422/999/890422999.geojson
+++ b/data/890/422/999/890422999.geojson
@@ -31,6 +31,9 @@
     "name:nld_x_preferred":[
         "Letogo"
     ],
+    "name:pol_x_preferred":[
+        "Letogo"
+    ],
     "name:und_x_variant":[
         "Letongo"
     ],
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890422999,
-    "wof:lastmodified":1566652725,
+    "wof:lastmodified":1690921724,
     "wof:name":"Letogo",
     "wof:parent_id":85680915,
     "wof:placetype":"locality",

--- a/data/890/429/403/890429403.geojson
+++ b/data/890/429/403/890429403.geojson
@@ -31,6 +31,9 @@
     "name:ceb_x_preferred":[
         "Vavau"
     ],
+    "name:deu_x_preferred":[
+        "Vavau"
+    ],
     "name:ell_x_preferred":[
         "\u0392\u03b1\u03b2\u03ac\u03bf\u03c5"
     ],
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":890429403,
-    "wof:lastmodified":1636504673,
+    "wof:lastmodified":1690921736,
     "wof:name":"Vavau",
     "wof:parent_id":85680925,
     "wof:placetype":"locality",

--- a/data/890/435/113/890435113.geojson
+++ b/data/890/435/113/890435113.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Vaisala"
     ],
+    "name:jpn_x_preferred":[
+        "\u30f4\u30a1\u30a4\u30b5\u30e9"
+    ],
     "name:nld_x_preferred":[
         "Vaisala"
     ],
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890435113,
-    "wof:lastmodified":1566652744,
+    "wof:lastmodified":1690921751,
     "wof:name":"Vaisala",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/141/890435141.geojson
+++ b/data/890/435/141/890435141.geojson
@@ -28,6 +28,9 @@
     "name:nld_x_preferred":[
         "Vaiee"
     ],
+    "name:tur_x_preferred":[
+        "Vaiee"
+    ],
     "name:und_x_variant":[
         "Vaiyee\u2019 Itai"
     ],
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890435141,
-    "wof:lastmodified":1566652743,
+    "wof:lastmodified":1690921750,
     "wof:name":"Vaie\u2019e",
     "wof:parent_id":85680915,
     "wof:placetype":"locality",

--- a/data/890/435/179/890435179.geojson
+++ b/data/890/435/179/890435179.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Siutu"
+    ],
     "name:eng_x_preferred":[
         "Siutu"
     ],
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890435179,
-    "wof:lastmodified":1566652744,
+    "wof:lastmodified":1690921751,
     "wof:name":"Siutu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/195/890435195.geojson
+++ b/data/890/435/195/890435195.geojson
@@ -22,7 +22,13 @@
     "name:ceb_x_preferred":[
         "Sili"
     ],
+    "name:deu_x_preferred":[
+        "Sili"
+    ],
     "name:eng_x_preferred":[
+        "Sili"
+    ],
+    "name:fra_x_preferred":[
         "Sili"
     ],
     "name:ita_x_preferred":[
@@ -32,6 +38,9 @@
         "\u30b7\u30ea"
     ],
     "name:nld_x_preferred":[
+        "Sili"
+    ],
+    "name:pol_x_preferred":[
         "Sili"
     ],
     "name:slk_x_preferred":[
@@ -71,7 +80,7 @@
         }
     ],
     "wof:id":890435195,
-    "wof:lastmodified":1566652738,
+    "wof:lastmodified":1690921744,
     "wof:name":"Sili",
     "wof:parent_id":85680953,
     "wof:placetype":"locality",

--- a/data/890/435/213/890435213.geojson
+++ b/data/890/435/213/890435213.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Savaia"
     ],
+    "name:deu_x_preferred":[
+        "Savaia"
+    ],
     "name:eng_x_preferred":[
         "Savaia"
     ],
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890435213,
-    "wof:lastmodified":1566652742,
+    "wof:lastmodified":1690921749,
     "wof:name":"Savaia",
     "wof:parent_id":85680917,
     "wof:placetype":"locality",

--- a/data/890/435/279/890435279.geojson
+++ b/data/890/435/279/890435279.geojson
@@ -22,8 +22,14 @@
     "name:eng_x_preferred":[
         "Sapulu village"
     ],
+    "name:eng_x_variant":[
+        "Sapulu"
+    ],
     "name:nld_x_preferred":[
         "Sapulu village"
+    ],
+    "name:nld_x_variant":[
+        "Sapulu"
     ],
     "qs:name":"Sapulu",
     "qs:photos_9r":0,
@@ -52,7 +58,7 @@
         }
     ],
     "wof:id":890435279,
-    "wof:lastmodified":1566652742,
+    "wof:lastmodified":1690921748,
     "wof:name":"Sapulu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/283/890435283.geojson
+++ b/data/890/435/283/890435283.geojson
@@ -28,6 +28,12 @@
     "name:nld_x_preferred":[
         "Sapapali'i"
     ],
+    "name:pol_x_preferred":[
+        "Sapapali'i"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0430\u043f\u0430\u043f\u0430\u043b\u0438\u0438"
+    ],
     "qs:name":"Sapapali\u2019i",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -59,7 +65,7 @@
         }
     ],
     "wof:id":890435283,
-    "wof:lastmodified":1566652741,
+    "wof:lastmodified":1690921748,
     "wof:name":"Sapapali\u2019i",
     "wof:parent_id":85680933,
     "wof:placetype":"locality",

--- a/data/890/435/287/890435287.geojson
+++ b/data/890/435/287/890435287.geojson
@@ -31,6 +31,12 @@
     "name:nld_x_preferred":[
         "Samatau"
     ],
+    "name:pol_x_preferred":[
+        "Samatau"
+    ],
+    "name:zho_x_preferred":[
+        "\u8428\u9a6c\u9676"
+    ],
     "qs:name":"Samatau",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -62,7 +68,7 @@
         }
     ],
     "wof:id":890435287,
-    "wof:lastmodified":1566652739,
+    "wof:lastmodified":1690921745,
     "wof:name":"Samatau",
     "wof:parent_id":85680921,
     "wof:placetype":"locality",

--- a/data/890/436/767/890436767.geojson
+++ b/data/890/436/767/890436767.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Vaiusu"
     ],
+    "name:deu_x_preferred":[
+        "Vaiusu"
+    ],
     "name:eng_x_preferred":[
         "Vaiusu"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890436767,
-    "wof:lastmodified":1566652730,
+    "wof:lastmodified":1690921734,
     "wof:name":"Vaiusu",
     "wof:parent_id":85680937,
     "wof:placetype":"locality",

--- a/data/890/436/847/890436847.geojson
+++ b/data/890/436/847/890436847.geojson
@@ -22,6 +22,9 @@
     "name:bul_x_preferred":[
         "\u0421\u0430\u0444\u043e\u0442\u0443"
     ],
+    "name:cat_x_preferred":[
+        "S\u0101fotu"
+    ],
     "name:ceb_x_preferred":[
         "Safotu"
     ],
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":890436847,
-    "wof:lastmodified":1566652730,
+    "wof:lastmodified":1690921735,
     "wof:name":"Safotu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/436/885/890436885.geojson
+++ b/data/890/436/885/890436885.geojson
@@ -22,13 +22,22 @@
     "name:ceb_x_preferred":[
         "Lotofaga"
     ],
+    "name:deu_x_preferred":[
+        "Lotofaga"
+    ],
     "name:eng_x_preferred":[
         "Lotofaga"
     ],
     "name:fas_x_preferred":[
         "\u0644\u0648\u062a\u0648\u0641\u0627\u06af\u0627"
     ],
+    "name:fra_x_preferred":[
+        "Lotofaga"
+    ],
     "name:nld_x_preferred":[
+        "Lotofaga"
+    ],
+    "name:pol_x_preferred":[
         "Lotofaga"
     ],
     "name:spa_x_preferred":[
@@ -68,7 +77,7 @@
         }
     ],
     "wof:id":890436885,
-    "wof:lastmodified":1566652730,
+    "wof:lastmodified":1690921735,
     "wof:name":"Lotofag\u0101",
     "wof:parent_id":85680937,
     "wof:placetype":"locality",

--- a/data/890/436/893/890436893.geojson
+++ b/data/890/436/893/890436893.geojson
@@ -28,10 +28,16 @@
     "name:ceb_x_preferred":[
         "Lufilufi"
     ],
+    "name:deu_x_preferred":[
+        "Lufilufi"
+    ],
     "name:ell_x_preferred":[
         "\u039b\u03bf\u03c5\u03c6\u03b9\u03bb\u03bf\u03cd\u03c6\u03b9"
     ],
     "name:eng_x_preferred":[
+        "Lufilufi"
+    ],
+    "name:fra_x_preferred":[
         "Lufilufi"
     ],
     "name:jpn_x_preferred":[
@@ -44,6 +50,9 @@
         "\u041b\u0443\u0444\u0438\u043b\u0443\u0444\u0438"
     ],
     "name:nld_x_preferred":[
+        "Lufilufi"
+    ],
+    "name:pol_x_preferred":[
         "Lufilufi"
     ],
     "name:urd_x_preferred":[
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":890436893,
-    "wof:lastmodified":1566652730,
+    "wof:lastmodified":1690921734,
     "wof:name":"Lufilufi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/442/005/890442005.geojson
+++ b/data/890/442/005/890442005.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Gataivai"
     ],
+    "name:deu_x_preferred":[
+        "Gataivai"
+    ],
     "name:eng_x_preferred":[
         "Gataivai"
     ],
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890442005,
-    "wof:lastmodified":1566652737,
+    "wof:lastmodified":1690921742,
     "wof:name":"Gataivai",
     "wof:parent_id":85680953,
     "wof:placetype":"locality",

--- a/data/890/452/821/890452821.geojson
+++ b/data/890/452/821/890452821.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Manase"
     ],
+    "name:fra_x_preferred":[
+        "Manase"
+    ],
     "name:nau_x_preferred":[
         "Manase"
     ],
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890452821,
-    "wof:lastmodified":1566652727,
+    "wof:lastmodified":1690921729,
     "wof:name":"Manase",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/452/823/890452823.geojson
+++ b/data/890/452/823/890452823.geojson
@@ -25,6 +25,9 @@
     "name:eng_x_preferred":[
         "Malua"
     ],
+    "name:fra_x_preferred":[
+        "Malua"
+    ],
     "name:nld_x_preferred":[
         "Malua"
     ],
@@ -55,7 +58,7 @@
         }
     ],
     "wof:id":890452823,
-    "wof:lastmodified":1566652728,
+    "wof:lastmodified":1690921730,
     "wof:name":"Malua",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/452/829/890452829.geojson
+++ b/data/890/452/829/890452829.geojson
@@ -22,13 +22,22 @@
     "name:ceb_x_preferred":[
         "Lotofaga"
     ],
+    "name:deu_x_preferred":[
+        "Lotofaga"
+    ],
     "name:eng_x_preferred":[
         "Lotofaga"
     ],
     "name:fas_x_preferred":[
         "\u0644\u0648\u062a\u0648\u0641\u0627\u06af\u0627"
     ],
+    "name:fra_x_preferred":[
+        "Lotofaga"
+    ],
     "name:nld_x_preferred":[
+        "Lotofaga"
+    ],
+    "name:pol_x_preferred":[
         "Lotofaga"
     ],
     "name:spa_x_preferred":[
@@ -68,7 +77,7 @@
         }
     ],
     "wof:id":890452829,
-    "wof:lastmodified":1566652727,
+    "wof:lastmodified":1690921729,
     "wof:name":"Lotofaga",
     "wof:parent_id":85680925,
     "wof:placetype":"locality",

--- a/data/890/452/831/890452831.geojson
+++ b/data/890/452/831/890452831.geojson
@@ -22,7 +22,13 @@
     "name:ceb_x_preferred":[
         "Lepea"
     ],
+    "name:deu_x_preferred":[
+        "Lepea"
+    ],
     "name:eng_x_preferred":[
+        "Lepea"
+    ],
+    "name:fra_x_preferred":[
         "Lepea"
     ],
     "name:nld_x_preferred":[
@@ -59,7 +65,7 @@
         }
     ],
     "wof:id":890452831,
-    "wof:lastmodified":1566652728,
+    "wof:lastmodified":1690921732,
     "wof:name":"Lepea",
     "wof:parent_id":85680915,
     "wof:placetype":"locality",

--- a/data/890/452/833/890452833.geojson
+++ b/data/890/452/833/890452833.geojson
@@ -28,6 +28,9 @@
     "name:fra_x_preferred":[
         "Lepa"
     ],
+    "name:heb_x_preferred":[
+        "\u05dc\u05e4\u05d4"
+    ],
     "name:nld_x_preferred":[
         "Lepa"
     ],
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890452833,
-    "wof:lastmodified":1566652727,
+    "wof:lastmodified":1690921730,
     "wof:name":"Lep\u0101",
     "wof:parent_id":85680925,
     "wof:placetype":"locality",

--- a/data/890/452/847/890452847.geojson
+++ b/data/890/452/847/890452847.geojson
@@ -22,10 +22,16 @@
     "name:bul_x_preferred":[
         "\u0424\u0430\u043b\u0435\u0430\u043f\u0443\u043d\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Fale\u0101puna"
+    ],
     "name:ceb_x_preferred":[
         "Faleolo"
     ],
     "name:ceb_x_variant":[
+        "Faleapuna"
+    ],
+    "name:deu_x_preferred":[
         "Faleapuna"
     ],
     "name:ell_x_preferred":[
@@ -70,7 +76,7 @@
         }
     ],
     "wof:id":890452847,
-    "wof:lastmodified":1566652728,
+    "wof:lastmodified":1690921731,
     "wof:name":"Faleapuna",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/452/851/890452851.geojson
+++ b/data/890/452/851/890452851.geojson
@@ -22,6 +22,9 @@
     "name:bul_x_preferred":[
         "\u0424\u0430\u043b\u0435\u043b\u0438\u043c\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Falelima"
+    ],
     "name:ceb_x_preferred":[
         "Falelima"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890452851,
-    "wof:lastmodified":1566652727,
+    "wof:lastmodified":1690921730,
     "wof:name":"Falelima",
     "wof:parent_id":85680943,
     "wof:placetype":"locality",

--- a/data/890/455/379/890455379.geojson
+++ b/data/890/455/379/890455379.geojson
@@ -25,10 +25,16 @@
     "name:ceb_x_preferred":[
         "Lalomanu"
     ],
+    "name:deu_x_preferred":[
+        "Lalomanu"
+    ],
     "name:ell_x_preferred":[
         "\u039b\u03b1\u03bb\u03bf\u03bc\u03ac\u03bd\u03bf\u03c5"
     ],
     "name:eng_x_preferred":[
+        "Lalomanu"
+    ],
+    "name:fra_x_preferred":[
         "Lalomanu"
     ],
     "name:nld_x_preferred":[
@@ -67,7 +73,7 @@
         }
     ],
     "wof:id":890455379,
-    "wof:lastmodified":1566652729,
+    "wof:lastmodified":1690921733,
     "wof:name":"Lalomanu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/455/381/890455381.geojson
+++ b/data/890/455/381/890455381.geojson
@@ -25,7 +25,13 @@
     "name:ceb_x_preferred":[
         "Lalomalava"
     ],
+    "name:deu_x_preferred":[
+        "Lalomalava"
+    ],
     "name:eng_x_preferred":[
+        "Lalomalava"
+    ],
+    "name:fra_x_preferred":[
         "Lalomalava"
     ],
     "name:jpn_x_preferred":[
@@ -65,7 +71,7 @@
         }
     ],
     "wof:id":890455381,
-    "wof:lastmodified":1566652729,
+    "wof:lastmodified":1690921733,
     "wof:name":"Lalomalava",
     "wof:parent_id":85680933,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.