### PR TITLE
ws concordances, placetype local, and more

### DIFF
--- a/data/856/326/81/85632681.geojson
+++ b/data/856/326/81/85632681.geojson
@@ -1052,6 +1052,7 @@
         "gp:id":23424992,
         "hasc:id":"WS",
         "ioc:id":"SAM",
+        "iso:code":"WS",
         "itu:id":"SMO",
         "m49:code":"882",
         "marc:id":"ws",
@@ -1065,6 +1066,7 @@
         "wk:page":"Samoa",
         "wmo:id":"ZM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
     "wof:country_alpha3":"WSM",
     "wof:geom_alt":[
@@ -1088,7 +1090,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1694639561,
+    "wof:lastmodified":1695881220,
     "wof:name":"Samoa",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/809/15/85680915.geojson
+++ b/data/856/809/15/85680915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037151,
-    "geom:area_square_m":445861091.959137,
+    "geom:area_square_m":445861063.185933,
     "geom:bbox":"-171.857894,-14.051853,-171.650217,-13.806346",
     "geom:latitude":-13.93413,
     "geom:longitude":-171.755145,
@@ -275,14 +275,16 @@
         "gn:id":4034977,
         "gp:id":20070339,
         "hasc:id":"WS.TU",
+        "iso:code":"WS-TU",
         "iso:id":"WS-TU",
         "qs_pg:id":236961,
         "unlc:id":"WS-TU",
         "wd:id":"Q1144482",
         "wk:page":"Tuamasaga"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"945d349ac877af38bf1f0f8501c6e7d6",
+    "wof:geomhash":"ecee6818c4e4949eafbce7160e768a4d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -299,7 +301,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921720,
+    "wof:lastmodified":1695884956,
     "wof:name":"Tuamasaga",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/17/85680917.geojson
+++ b/data/856/809/17/85680917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024448,
-    "geom:area_square_m":293456436.003826,
+    "geom:area_square_m":293456519.372334,
     "geom:bbox":"-172.055613,-14.007013,-171.844071,-13.805352",
     "geom:latitude":-13.898654,
     "geom:longitude":-171.924271,
@@ -278,13 +278,15 @@
         "gn:id":4035434,
         "gp:id":20070340,
         "hasc:id":"WS.AA",
+        "iso:code":"WS-AA",
         "iso:id":"WS-AA",
         "qs_pg:id":890130,
         "unlc:id":"WS-AA",
         "wd:id":"Q1154121"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"4328ca77300c0496e4af900865affb93",
+    "wof:geomhash":"02dfc81b1458c23d28af14fb8e10bbc7",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -301,7 +303,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921717,
+    "wof:lastmodified":1695884956,
     "wof:name":"A'ana",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/21/85680921.geojson
+++ b/data/856/809/21/85680921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00412,
-    "geom:area_square_m":49461729.950569,
+    "geom:area_square_m":49461870.60598,
     "geom:bbox":"-172.063669,-13.915216,-171.972239,-13.82821",
     "geom:latitude":-13.873862,
     "geom:longitude":-172.019047,
@@ -281,14 +281,16 @@
         "gn:id":4035425,
         "gp:id":20070341,
         "hasc:id":"WS.AL",
+        "iso:code":"WS-AL",
         "iso:id":"WS-AL",
         "qs_pg:id":49500,
         "unlc:id":"WS-AL",
         "wd:id":"Q1144488",
         "wk:page":"Aiga-i-le-Tai"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"dc6f1eaf3cf7ee881ceca990318b5d7a",
+    "wof:geomhash":"d32ab1da5c9ee7444557533c7db6957a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -305,7 +307,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921717,
+    "wof:lastmodified":1695884956,
     "wof:name":"Aiga-i-le-Tai",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/25/85680925.geojson
+++ b/data/856/809/25/85680925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022379,
-    "geom:area_square_m":268522022.856639,
+    "geom:area_square_m":268522535.334263,
     "geom:bbox":"-171.665552,-14.05283,-171.437693,-13.87127",
     "geom:latitude":-13.982611,
     "geom:longitude":-171.574934,
@@ -265,14 +265,16 @@
         "gn:id":4035402,
         "gp:id":20070345,
         "hasc:id":"WS.AT",
+        "iso:code":"WS-AT",
         "iso:id":"WS-AT",
         "qs_pg:id":49502,
         "unlc:id":"WS-AT",
         "wd:id":"Q1154332",
         "wk:page":"Atua (district)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"0f07a137f6d9221ebbf6999a1ca7c71d",
+    "wof:geomhash":"bd67e3e45fe05fa5d521e0a7a56b3735",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -289,7 +291,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921720,
+    "wof:lastmodified":1695884956,
     "wof:name":"Atua",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/31/85680931.geojson
+++ b/data/856/809/31/85680931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004294,
-    "geom:area_square_m":51529691.955572,
+    "geom:area_square_m":51529922.841957,
     "geom:bbox":"-171.599179,-13.991974,-171.46935,-13.883884",
     "geom:latitude":-13.956416,
     "geom:longitude":-171.541885,
@@ -272,14 +272,16 @@
         "gn:id":4034943,
         "gp:id":20070346,
         "hasc:id":"WS.VF",
+        "iso:code":"WS-VF",
         "iso:id":"WS-VF",
         "qs_pg:id":349026,
         "unlc:id":"WS-VF",
         "wd:id":"Q1154109",
         "wk:page":"Va'a-o-Fonoti"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"84f931fbb0fa00bed7d6ccc9852a53fc",
+    "wof:geomhash":"cdc0ebd603dde69874e1d346054d2e5b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -296,7 +298,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921718,
+    "wof:lastmodified":1695884956,
     "wof:name":"Va'a-o-Fonoti",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/33/85680933.geojson
+++ b/data/856/809/33/85680933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019333,
-    "geom:area_square_m":232296440.363888,
+    "geom:area_square_m":232296267.739058,
     "geom:bbox":"-172.310967,-13.800958,-172.175649,-13.558364",
     "geom:latitude":-13.657486,
     "geom:longitude":-172.243546,
@@ -275,14 +275,16 @@
         "gn:id":4035383,
         "gp:id":20070338,
         "hasc:id":"WS.FA",
+        "iso:code":"WS-FA",
         "iso:id":"WS-FA",
         "qs_pg:id":1287673,
         "unlc:id":"WS-FA",
         "wd:id":"Q1154134",
         "wk:page":"Fa'asaleleaga"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"0e7efda9a8184e17b5a4c52e88561d47",
+    "wof:geomhash":"d02cf755b74611922507fb1cbc86dcef",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -299,7 +301,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921716,
+    "wof:lastmodified":1695884956,
     "wof:name":"Fa'asaleleaga",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/37/85680937.geojson
+++ b/data/856/809/37/85680937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021248,
-    "geom:area_square_m":255376145.230711,
+    "geom:area_square_m":255376399.75395,
     "geom:bbox":"-172.414185,-14.004691,-171.791431,-13.462823",
     "geom:latitude":-13.596293,
     "geom:longitude":-172.274554,
@@ -277,14 +277,16 @@
         "gn:id":4035314,
         "gp:id":20070344,
         "hasc:id":"WS.GE",
+        "iso:code":"WS-GE",
         "iso:id":"WS-GE",
         "qs_pg:id":1287674,
         "unlc:id":"WS-GE",
         "wd:id":"Q1193143",
         "wk:page":"Gaga'emauga"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"7431502ee3c9832493a065875cfcac08",
+    "wof:geomhash":"061f57f0d906cc3cf2338e16e33613b3",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -301,7 +303,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921719,
+    "wof:lastmodified":1695884956,
     "wof:name":"Gaga'emauga",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/39/85680939.geojson
+++ b/data/856/809/39/85680939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034395,
-    "geom:area_square_m":413443720.051483,
+    "geom:area_square_m":413442130.688232,
     "geom:bbox":"-172.638987,-13.636866,-172.36616,-13.462823",
     "geom:latitude":-13.556489,
     "geom:longitude":-172.50269,
@@ -284,14 +284,16 @@
         "gn:id":4035313,
         "gp:id":20070337,
         "hasc:id":"WS.GI",
+        "iso:code":"WS-GI",
         "iso:id":"WS-GI",
         "qs_pg:id":236960,
         "unlc:id":"WS-GI",
         "wd:id":"Q1193134",
         "wk:page":"Gaga'ifomauga"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"cde11c6353411c643ee27f0ab63ec8fd",
+    "wof:geomhash":"1dabf1c79758cc584886da3019151f0d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -308,7 +310,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921719,
+    "wof:lastmodified":1695884956,
     "wof:name":"Gaga'ifomauga",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/43/85680943.geojson
+++ b/data/856/809/43/85680943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010016,
-    "geom:area_square_m":120400301.091732,
+    "geom:area_square_m":120400577.127863,
     "geom:bbox":"-172.782582,-13.616632,-172.631809,-13.510512",
     "geom:latitude":-13.555587,
     "geom:longitude":-172.703373,
@@ -278,14 +278,16 @@
         "gn:id":4034910,
         "gp:id":20070336,
         "hasc:id":"WS.VS",
+        "iso:code":"WS-VS",
         "iso:id":"WS-VS",
         "qs_pg:id":49499,
         "unlc:id":"WS-VS",
         "wd:id":"Q1193139",
         "wk:page":"Vaisigano"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"b04ad5a60f1c940b90851c498cc8b6a4",
+    "wof:geomhash":"0f42ee8e1362f22453c0085cf26374af",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -302,7 +304,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921717,
+    "wof:lastmodified":1695884956,
     "wof:name":"Vaisigano",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/49/85680949.geojson
+++ b/data/856/809/49/85680949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01197,
-    "geom:area_square_m":143821927.952473,
+    "geom:area_square_m":143823566.811905,
     "geom:bbox":"-172.703481,-13.783994,-172.31843,-13.584584",
     "geom:latitude":-13.669331,
     "geom:longitude":-172.499494,
@@ -277,14 +277,16 @@
         "gn:id":4035046,
         "gp:id":20070342,
         "hasc:id":"WS.SA",
+        "iso:code":"WS-SA",
         "iso:id":"WS-SA",
         "qs_pg:id":49501,
         "unlc:id":"WS-SA",
         "wd:id":"Q651573",
         "wk:page":"Satupa'itea"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"90c9bb560c5974e7a4422d2a78a9844a",
+    "wof:geomhash":"dba1a05415159205a2e2614e1fe007ad",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -301,7 +303,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921720,
+    "wof:lastmodified":1695884956,
     "wof:name":"Satupa'itea",
     "wof:parent_id":85632681,
     "wof:placetype":"region",

--- a/data/856/809/53/85680953.geojson
+++ b/data/856/809/53/85680953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043023,
-    "geom:area_square_m":516818709.940804,
+    "geom:area_square_m":516816732.856309,
     "geom:bbox":"-172.608957,-13.805352,-172.212961,-13.632646",
     "geom:latitude":-13.717782,
     "geom:longitude":-172.440782,
@@ -281,14 +281,16 @@
         "gn:id":4035154,
         "gp:id":20070343,
         "hasc:id":"WS.PA",
+        "iso:code":"WS-PA",
         "iso:id":"WS-PA",
         "qs_pg:id":894097,
         "unlc:id":"WS-PA",
         "wd:id":"Q1147216",
         "wk:page":"Palauli"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"WS",
-    "wof:geomhash":"441cb6b025dc442391ea659b7b2bcb2e",
+    "wof:geomhash":"5ba6891775d98f7391a439b4e2bbac73",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -305,7 +307,7 @@
         "smo",
         "eng"
     ],
-    "wof:lastmodified":1690921718,
+    "wof:lastmodified":1695884956,
     "wof:name":"Palauli",
     "wof:parent_id":85632681,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.